### PR TITLE
Change 'Wikipedia' to 'Wiki'

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -86,4 +86,5 @@ Previously involved:
 - *Edder Bustos Diaz [@EdderDaniel](https://github.com/EdderDaniel)*
 
 Contributors:
+- *Caspar Schmeits [@Capspar](https://github.com/Capspar)*
 - You!


### PR DESCRIPTION
Hi,

I have made a few very small changes to the main page of the IBL Bioinformatics Wiki.

Namely, I have changed "Wikipedia" into "Wiki", since in my view "Wikipedia" specifically refers to the famous encyclopedia we all know. I think "Wiki" is the general term that should be used. Also, I have capitalized "Bioinformatics" in the title.

I realize that this contribution is not very meaningful for the content of the Wiki, but at least it has served as an exercise for me on how to make changes in a Github codebase and create pull requests.

Feel free to implement these changes if you agree.

Thank you!